### PR TITLE
Add remainder http methods. vite.config update. 

### DIFF
--- a/src/routes/api/[...slugs]/+server.ts
+++ b/src/routes/api/[...slugs]/+server.ts
@@ -10,3 +10,5 @@ export const GET: RequestHandler = ({ request }) => app.fetch(request);
 export const PUT: RequestHandler = ({ request }) => app.fetch(request);
 export const DELETE: RequestHandler = ({ request }) => app.fetch(request);
 export const POST: RequestHandler = ({ request }) => app.fetch(request);
+export const PATCH: RequestHandler = ({ request }) => app.fetch(request);
+export const OPTIONS: RequestHandler = ({ request }) => app.fetch(request);

--- a/src/routes/api/[...slugs]/+server.ts
+++ b/src/routes/api/[...slugs]/+server.ts
@@ -12,3 +12,5 @@ export const DELETE: RequestHandler = ({ request }) => app.fetch(request);
 export const POST: RequestHandler = ({ request }) => app.fetch(request);
 export const PATCH: RequestHandler = ({ request }) => app.fetch(request);
 export const OPTIONS: RequestHandler = ({ request }) => app.fetch(request);
+export const HEAD: RequestHandler = ({ request }) => app.fetch(request);
+export const fallback: RequestHandler = ({ request }) => app.fetch(request);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,5 +2,8 @@ import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig } from 'vite';
 
 export default defineConfig({
-	plugins: [sveltekit()]
+	plugins: [sveltekit()],
+	optimizeDeps: {
+		exclude: ['oslo']
+	}
 });


### PR DESCRIPTION
This adds the remainder http methods for proxying.  You can technically remove all the explicit `PUT`, `DELETE`, `GET` handlers in favor of just having the `fallback` method; but we utilize this for error handling instead(since we don't utilize `MOVE` ect...).

Also; the crypto libraries probably should not be optimized by Vite. Adding `oslo` to the exclusion will silence a warning you might see from time to time in the console when vite attempts pre-bundling. 

There is a lot of cool stuff missing from the repo I shared of whats possible. Sometime this weekend I'll add more from our internal boilerplate. 